### PR TITLE
Change to python 3.x support (via 2to3 utility)

### DIFF
--- a/amqp_codegen.py
+++ b/amqp_codegen.py
@@ -119,7 +119,7 @@ mergers = {
 }
 
 def merge_load_specs(filenames, ignore_conflicts):
-    handles = [file(filename) for filename in filenames]
+    handles = [open(filename) for filename in filenames]
     docs = [json.load(handle) for handle in handles]
     spec = {}
     for doc in docs:


### PR DESCRIPTION
One very minor change to allow amqp_codegen.py to be used with python 3.x

This should not have any effect on its compatibility with python 2.x
- I've tested it with python 2.7.1 and 2.6.7 using the [alanxz/rabbitmq-c@issue47_python3_support](https://github.com/alanxz/rabbitmq-c/tree/issue47_python3_support) codegen.py
- I have not tested it with any of the other code generators
