### PR TITLE
URL Cleanup

### DIFF
--- a/amqp-1.0/messaging.xml
+++ b/amqp-1.0/messaging.xml
@@ -32,7 +32,7 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 -->
 
-<amqp name="messaging" xmlns="http://www.amqp.org/schema/amqp.xsd">
+<amqp name="messaging" xmlns="https://www.amqp.org/schema/amqp.xsd">
   <section name="message-format">
     <type name="header" class="composite" source="list" provides="section">
       <descriptor name="amqp:header:list" code="0x00000000:0x00000070"/>

--- a/amqp-1.0/security.xml
+++ b/amqp-1.0/security.xml
@@ -32,7 +32,7 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 -->
 
-<amqp name="security" xmlns="http://www.amqp.org/schema/amqp.xsd">
+<amqp name="security" xmlns="https://www.amqp.org/schema/amqp.xsd">
   <section name="tls">
     <definition name="TLS-MAJOR" value="1"/>
     <definition name="TLS-MINOR" value="0"/>

--- a/amqp-1.0/transactions.xml
+++ b/amqp-1.0/transactions.xml
@@ -32,7 +32,7 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 -->
 
-<amqp name="transactions" xmlns="http://www.amqp.org/schema/amqp.xsd">
+<amqp name="transactions" xmlns="https://www.amqp.org/schema/amqp.xsd">
   <section name="coordination">
     <type name="coordinator" class="composite" source="list" provides="target">
       <descriptor name="amqp:coordinator:list" code="0x00000000:0x00000030"/>

--- a/amqp-1.0/transport.xml
+++ b/amqp-1.0/transport.xml
@@ -32,7 +32,7 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 -->
 
-<amqp name="transport" xmlns="http://www.amqp.org/schema/amqp.xsd">
+<amqp name="transport" xmlns="https://www.amqp.org/schema/amqp.xsd">
   <section name="performatives">
     <type name="open" class="composite" source="list" provides="frame">
       <descriptor name="amqp:open:list" code="0x00000000:0x00000010"/>

--- a/amqp-1.0/types.xml
+++ b/amqp-1.0/types.xml
@@ -32,7 +32,7 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 -->
 
-<amqp name="types" xmlns="http://www.amqp.org/schema/amqp.xsd">
+<amqp name="types" xmlns="https://www.amqp.org/schema/amqp.xsd">
   <section name="encodings">
     <type name="null" class="primitive">
       <encoding code="0x40" category="fixed" width="0"/>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://www.amqp.org/schema/amqp.xsd (404) with 5 occurrences migrated to:  
  https://www.amqp.org/schema/amqp.xsd ([https](https://www.amqp.org/schema/amqp.xsd) result 404).