### PR TITLE
URL Cleanup

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -40,5 +40,5 @@ appropriate to the circumstances. Maintainers are obligated to maintain confiden
 with regard to the reporter of an incident.
 
 This Code of Conduct is adapted from the
-[Contributor Covenant](http://contributor-covenant.org), version 1.3.0, available at
-[contributor-covenant.org/version/1/3/0/](http://contributor-covenant.org/version/1/3/0/)
+[Contributor Covenant](https://contributor-covenant.org), version 1.3.0, available at
+[contributor-covenant.org/version/1/3/0/](https://contributor-covenant.org/version/1/3/0/)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ The process is fairly standard:
  * Clone [RabbitMQ umbrella repository](https://github.com/rabbitmq/rabbitmq-public-umbrella)
  * `cd umbrella`, `make co`
  * Create a branch with a descriptive name in the relevant repositories
- * Make your changes, run tests, commit with a [descriptive message](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html), push to your fork
+ * Make your changes, run tests, commit with a [descriptive message](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html), push to your fork
  * Submit pull requests with an explanation what has been changed and **why**
  * Submit a filled out and signed [Contributor Agreement](https://github.com/rabbitmq/ca#how-to-submit) if needed (see below)
  * Be patient. We will get to your pull request eventually

--- a/LICENSE-MPL-RabbitMQ
+++ b/LICENSE-MPL-RabbitMQ
@@ -437,7 +437,7 @@ EXHIBIT A -Mozilla Public License.
      ``The contents of this file are subject to the Mozilla Public License
      Version 1.1 (the "License"); you may not use this file except in
      compliance with the License. You may obtain a copy of the License at
-     http://www.mozilla.org/MPL/
+     https://www.mozilla.org/MPL/
 
      Software distributed under the License is distributed on an "AS IS"
      basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the

--- a/README.extensions.md
+++ b/README.extensions.md
@@ -17,7 +17,7 @@ specification document is therefore non-commutative.
 ## The main document
 
 Written in the style of a
-[json-shapes](http://github.com/tonyg/json-shapes) schema:
+[json-shapes](https://github.com/tonyg/json-shapes) schema:
 
     DomainDefinition = _and(array_of(string()), array_length_equals(2));
 
@@ -89,7 +89,7 @@ straightforward numeric constant.
 ## Extensions
 
 Written in the style of a
-[json-shapes](http://github.com/tonyg/json-shapes) schema, and
+[json-shapes](https://github.com/tonyg/json-shapes) schema, and
 referencing some of the type definitions given above:
 
     ExtensionDocument = {

--- a/amqp-rabbitmq-0.8.json
+++ b/amqp-rabbitmq-0.8.json
@@ -29,7 +29,7 @@
         "Class information entered from amqp_xml0-8.pdf and domain types from amqp-xml-doc0-9.pdf\n",
         "\n",
         "b3cb053f15e7b98808c0ccc67f23cb3e  amqp_xml0-8.pdf\n",
-        "http://www.twiststandards.org/index.php?option=com_docman&task=cat_view&gid=28&&Itemid=90\n",
+        "http://twiststandards.org/?option=com_docman&task=cat_view&gid=28&Itemid=90\n",
         "8444db91e2949dbecfb2585e9eef6d64  amqp-xml-doc0-9.pdf\n",
         "https://jira.amqp.org/confluence/download/attachments/720900/amqp-xml-doc0-9.pdf?version=1\n"],
 

--- a/amqp-rabbitmq-0.9.1.json
+++ b/amqp-rabbitmq-0.9.1.json
@@ -31,7 +31,7 @@
         "Updated for 0-9-1 by Tony Garnock-Jones\n",
         "\n",
         "b3cb053f15e7b98808c0ccc67f23cb3e  amqp_xml0-8.pdf\n",
-        "http://www.twiststandards.org/index.php?option=com_docman&task=cat_view&gid=28&&Itemid=90\n",
+        "http://twiststandards.org/?option=com_docman&task=cat_view&gid=28&Itemid=90\n",
         "8444db91e2949dbecfb2585e9eef6d64  amqp-xml-doc0-9.pdf\n",
         "https://jira.amqp.org/confluence/download/attachments/720900/amqp-xml-doc0-9.pdf?version=1\n"],
 

--- a/amqp_codegen.py
+++ b/amqp_codegen.py
@@ -1,7 +1,7 @@
 ##  The contents of this file are subject to the Mozilla Public License
 ##  Version 1.1 (the "License"); you may not use this file except in
 ##  compliance with the License. You may obtain a copy of the License
-##  at http://www.mozilla.org/MPL/
+##  at https://www.mozilla.org/MPL/
 ##
 ##  Software distributed under the License is distributed on an "AS IS"
 ##  basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
@@ -37,7 +37,7 @@ except ImportError:
     print("   - by running 'yum install python-simplejson' on Fedora/Red Hat system,", file = sys.stderr)
     print("   - by running 'port install py25-simplejson' on Macports on OS X", file = sys.stderr)
     print("     (you may need to say 'make PYTHON=python2.5', as well),", file = sys.stderr)
-    print("   - from sources from 'http://pypi.python.org/pypi/simplejson'", file = sys.stderr)
+    print("   - from sources from 'https://pypi.python.org/pypi/simplejson'", file = sys.stderr)
     print("   - simplejson is a standard json library in the Python core since 2.6", file = sys.stderr)
     sys.exit(1)
 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* http://www.twiststandards.org/index.php?option=com_docman&task=cat_view&gid=28&&Itemid=90 (301) with 2 occurrences could not be migrated:  
   ([https](https://www.twiststandards.org/index.php?option=com_docman&task=cat_view&gid=28&&Itemid=90) result SSLHandshakeException).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://github.com/tonyg/json-shapes with 2 occurrences migrated to:  
  https://github.com/tonyg/json-shapes ([https](https://github.com/tonyg/json-shapes) result 200).
* http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html with 1 occurrences migrated to:  
  https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html ([https](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html) result 200).
* http://contributor-covenant.org with 1 occurrences migrated to:  
  https://contributor-covenant.org ([https](https://contributor-covenant.org) result 301).
* http://contributor-covenant.org/version/1/3/0/ with 1 occurrences migrated to:  
  https://contributor-covenant.org/version/1/3/0/ ([https](https://contributor-covenant.org/version/1/3/0/) result 301).
* http://pypi.python.org/pypi/simplejson with 1 occurrences migrated to:  
  https://pypi.python.org/pypi/simplejson ([https](https://pypi.python.org/pypi/simplejson) result 301).
* http://www.mozilla.org/MPL/ with 2 occurrences migrated to:  
  https://www.mozilla.org/MPL/ ([https](https://www.mozilla.org/MPL/) result 301).